### PR TITLE
Adding option to include pvt configs without tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,4 +397,7 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 *.pyproj
+
+# Project files
 /keys
+eureka_ml_insights/configs/pvt_model_configs.py

--- a/eureka_ml_insights/configs/pvt_model_configs.py
+++ b/eureka_ml_insights/configs/pvt_model_configs.py
@@ -1,0 +1,22 @@
+""" This module contains config objects for the models used in the experiments. To use these configs, make sure to
+replace the placeholders with your own keys.json file, secret key names, and endpint URLs where applicable. 
+You can also add your custom models here by following the same pattern as the existing configs. """
+
+from eureka_ml_insights.models import (
+    AzureOpenAIO1Model,
+    ClaudeModel,
+    DirectOpenAIModel,
+    DirectOpenAIO1Model,
+    GeminiModel,
+    LlamaServerlessAzureRestEndpointModel,
+    LLaVAHuggingFaceModel,
+    LLaVAModel,
+    MistralServerlessAzureRestEndpointModel,
+    RestEndpointModel,
+    TestModel,
+)
+from eureka_ml_insights.models.models import AzureOpenAIModel
+
+from .config import ModelConfig
+
+# include any private model configs and keys you require here. this file is gitignored

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import logging
 
 from eureka_ml_insights import user_configs as configs
 from eureka_ml_insights.configs import model_configs
+from eureka_ml_insights.configs import pvt_model_configs
 from eureka_ml_insights.core import Pipeline
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -39,10 +40,16 @@ if __name__ == "__main__":
 
     experiment_config_class = args.exp_config
     if args.model_config:
+        logging.info(f"Using model config {args.model_config}.")
         try:
+            logging.info(f"Trying to import model config from model_configs.")
             init_args["model_config"] = getattr(model_configs, args.model_config)
         except AttributeError:
-            raise ValueError(f"Model config class {args.model_config} not found.")
+            try:
+                logging.info(f"Trying to import model config from pvt_model_configs.")
+                init_args["model_config"] = getattr(pvt_model_configs, args.model_config)
+            except AttributeError:
+                raise ValueError(f"Model config class {args.model_config} not found.")
 
     if args.resume_from:
         init_args["resume_from"] = args.resume_from


### PR DESCRIPTION
Feature - add pvt configs to eureka_ml_insights/configs/pvt_model_configs.py without git tracking

1. pvt_model_configs.py - to include private model configs and keys required for the experiments.
2. main.py - to check in pvt_model_configs in addition to model_configs
3. .gitignore - adding pvt_model_co to the gitignore file to prevent tracking