### PR TITLE
Adds support for vLLM-based models.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -203,7 +203,7 @@ dependencies:
   - tbb=2021.8.0=hdb19cb5_0
   - tk=8.6.12=h1ccaba5_0
   - tokenizers=0.19.1=py311h585d796_0
-  - torchaudio=2.2.1=py311_cu118
+  - torchaudio=2.5.1=py311_cu118
   - tornado=6.4=py311h459d7ec_0
   - tqdm=4.65.0=py311h92b7b1e_0
   - traitlets=5.14.3=pyhd8ed1ab_0
@@ -368,8 +368,8 @@ dependencies:
       - tinycss2==1.3.0
       - tomlkit==0.12.0
       - toolz==0.12.1
-      - torch==2.1.2
-      - torchvision==0.16.2
+      - torch==2.5.1
+      - torchvision==0.20.1
       - transformers==4.40.2
       - triton==2.1.0
       - typer==0.9.0

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -10,4 +10,5 @@ dependencies:
   - pip:
       - deepspeed==0.14.4
       - flash-attn==2.6.3
+      - vllm==0.7.2
       - git+https://github.com/neelsj/LLaVA.git

--- a/eureka_ml_insights/models/__init__.py
+++ b/eureka_ml_insights/models/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     Phi4HFModel,
     RestEndpointModel,
     TestModel,
+    vLLMModel,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     LLaVAModel,
     RestEndpointModel,
     TestModel,
+    vLLMModel,
 ]

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -1047,7 +1047,7 @@ class vLLMModel(Model):
     top_p: float = 0.95
     top_k: int = -1
     max_tokens: int = 2000
-    apply_model_template: bool = True
+    apply_model_template: bool = False
 
     def __post_init__(self):
         # vLLM automatically picks an available devices when get_model() is called
@@ -1113,7 +1113,7 @@ class vLLMModel(Model):
         return response_dict
 
     def model_template_fn(self, text_prompt, system_message=None):
-        return system_message + " " + text_prompt if system_message else text_prompt
+        raise NotImplementedError
 
 
 @dataclass

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'jsonlines>=2.0.0',
         'pandas>=2.2.1',
         'pillow>=10.0.1',
-        'torch==2.1.2',
+        'torch==2.5.1',
         'numpy==1.26.4',
         'tqdm>=4.65.0',
         'jinja2>=3.1.3',
@@ -40,6 +40,7 @@ setup(
         'bitsandbytes>=0.42.0',
         'accelerate>=0.21.0',
         'pycocotools>=2.0.8',
+        'vllm==0.7.2',
     ],
     classifiers=[
         # Full list at https://pypi.org/classifiers/


### PR DESCRIPTION
This PR implements a `vLLMModel` class, which adds support for performing generations with vLLM, as follows:

```python
from eureka_ml_insights.models.models import vLLMModel

vllm_model = vLLMModel(model_name="gpt2", max_tokens=10, gpu_memory_utilization=0.1)
print(vllm_model.generate("Hello"))
```

One thing which is still open for discussion is what would be the best way to add vLLM as a requirement, since `torch==2.1.2` and the latest vLLM (0.7.2) would require `torch==2.5.1`.

Please let me know your thoughts!