### PR TITLE
use vllm's template conversion

### DIFF
--- a/eureka_ml_insights/models/__init__.py
+++ b/eureka_ml_insights/models/__init__.py
@@ -15,7 +15,7 @@ from .models import (
     Phi4HFModel,
     RestEndpointModel,
     TestModel,
-    vLLMModel,
+    VLLMModel,
     TogetherModel
 )
 
@@ -36,6 +36,6 @@ __all__ = [
     LLaVAModel,
     RestEndpointModel,
     TestModel,
-    vLLMModel,
+    VLLMModel,
     TogetherModel
 ]

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -1130,10 +1130,10 @@ class VLLMModel(Model):
         response_dict = {}
 
         if text_prompt:
-            text_prompt = self.model_template_fn(text_prompt, system_message)
+            messages = self.create_request(text_prompt, system_message)
 
             try:
-                meta_response = self._generate(text_prompt, query_images=query_images)
+                meta_response = self._generate(messages, query_images=query_images)
                 if meta_response:
                     response_dict.update(meta_response)
                 self.is_valid = True
@@ -1152,7 +1152,7 @@ class VLLMModel(Model):
         )
         return response_dict
 
-    def model_template_fn(self, text_prompt, system_message=None):
+    def create_request(self, text_prompt, system_message=None):
         if system_message:
             return [
                 {"role": "system", "content": system_message},

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -1070,7 +1070,7 @@ class LLaVAModel(LLaVAHuggingFaceModel):
 
 
 @dataclass
-class vLLMModel(Model):
+class VLLMModel(Model):
     """This class is used to run a self-hosted language model via vLLM apis.
     This class uses the chat() functionality of vLLM which applies a template included in the HF model files.
     If the model files do not include a template, no template will be applied.

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -1117,7 +1117,7 @@ class vLLMModel(Model):
         )
     
         start_time = time.time()
-        outputs = self.model.generate(text_prompt, sampling_params)
+        outputs = self.model.chat(text_prompt, sampling_params)
         end_time = time.time()
         
         self.model_output = outputs[0].outputs[0].text
@@ -1128,8 +1128,7 @@ class vLLMModel(Model):
         response_dict = {}
 
         if text_prompt:
-            if self.apply_model_template:
-                text_prompt = self.model_template_fn(text_prompt, system_message)
+            text_prompt = self.model_template_fn(text_prompt, system_message)
 
             try:
                 meta_response = self._generate(text_prompt, query_images=query_images)
@@ -1152,7 +1151,13 @@ class vLLMModel(Model):
         return response_dict
 
     def model_template_fn(self, text_prompt, system_message=None):
-        raise NotImplementedError
+        if system_message:
+            return [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": text_prompt},
+            ]
+        else:
+            return [{"role": "user", "content": text_prompt}]
 
 
 @dataclass

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -1071,7 +1071,10 @@ class LLaVAModel(LLaVAHuggingFaceModel):
 
 @dataclass
 class vLLMModel(Model):
-    """This class is used to run a self-hosted language model via vLLM apis."""
+    """This class is used to run a self-hosted language model via vLLM apis.
+    This class uses the chat() functionality of vLLM which applies a template included in the HF model files.
+    If the model files do not include a template, no template will be applied.
+    """
 
     model_name: str = None
     trust_remote_code: bool = False
@@ -1086,7 +1089,6 @@ class vLLMModel(Model):
     top_p: float = 0.95
     top_k: int = -1
     max_tokens: int = 2000
-    apply_model_template: bool = False
 
     def __post_init__(self):
         # vLLM automatically picks an available devices when get_model() is called


### PR DESCRIPTION
Replaces model_template_fn in vLLMModel with the usual prompt -> messages conversion, and then calling vllm's chat instead of generate.  This allows for calling any (vllm supported) hf model without needing to implement model_template_fn for individual models.