### PR TITLE
Report aggregation change for gpqa, Claude 3.7 config update

### DIFF
--- a/eureka_ml_insights/configs/model_configs.py
+++ b/eureka_ml_insights/configs/model_configs.py
@@ -209,8 +209,8 @@ CLAUDE_3_7_SONNET_THINKING_CONFIG = ModelConfig(
         "secret_key_params": CLAUDE_SECRET_KEY_PARAMS,
         "model_name": "claude-3-7-sonnet-20250219",
         "thinking_enabled": True,
-        "thinking_budget": 16000,
-        "max_tokens": 20000, # This number should always be higher than the thinking budget
+        "thinking_budget": 30720,
+        "max_tokens": 32768, # This number should always be higher than the thinking budget
         "temperature": 1.0, # As of 03/08/2025, thinking only works with temperature 1.0
         "timeout": 600, # We set a timeout of 10 minutes for thinking
     },

--- a/eureka_ml_insights/user_configs/gpqa.py
+++ b/eureka_ml_insights/user_configs/gpqa.py
@@ -265,14 +265,14 @@ class GPQA_Experiment_Pipeline(ExperimentConfig):
                 AggregatorConfig(BiLevelAggregator, 
                     {
                         "column_names": ["usage_completion"], 
-                        "first_groupby": "data_point_id", 
+                        "first_groupby": "data_repeat_id", 
                         "filename_base": "UsageCompletion_AllRuns",
                         "agg_fn": "mean"
                     }),
                 AggregatorConfig(BiLevelAggregator, 
                     {
                         "column_names": ["usage_completion"], 
-                        "first_groupby": ["data_point_id", "Subdomain"], 
+                        "first_groupby": ["data_repeat_id", "Subdomain"], 
                         "second_groupby": "Subdomain",
                         "filename_base": "UsageCompletion_GroupBy_Subdomain_AllRuns", 
                         "agg_fn": "mean"
@@ -280,7 +280,7 @@ class GPQA_Experiment_Pipeline(ExperimentConfig):
                 AggregatorConfig(BiLevelAggregator, 
                     {
                         "column_names": ["usage_completion"], 
-                        "first_groupby": ["data_point_id", "High-level domain"], 
+                        "first_groupby": ["data_repeat_id", "High-level domain"], 
                         "second_groupby": "High-level domain",
                         "filename_base": "UsageCompletion_GroupBy_High-level_domain_AllRuns",
                         "agg_fn": "mean" 


### PR DESCRIPTION
- The aggregations for token usage now aggregate by data_repeat_id first. This is so our error bars match the ones showed for accuracy.

- Updating the max tokens of claude 3.7 so that it sums up to 32k