### PR TITLE
minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.egg-info
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/eureka_ml_insights/configs/config.py
+++ b/eureka_ml_insights/configs/config.py
@@ -33,7 +33,7 @@ class DataSetConfig(UtilityClassConfig):
     pass
 
 
-@dataclass
+@dataclass(repr=False)
 class ModelConfig(UtilityClassConfig):
     pass
 

--- a/eureka_ml_insights/data_utils/transform.py
+++ b/eureka_ml_insights/data_utils/transform.py
@@ -269,7 +269,8 @@ class ImputeNA(MultiColumnTransform):
     value: str
 
     def _transform(self, value):
-        if pd.isna(value):
+        isna = pd.isna(value)
+        if isinstance(isna, bool) and isna:
             return self.value
         return value
 


### PR DESCRIPTION
Three small fixes:
1) update gitignore to ignore files from editable install

2) fixing issue where logs contain api_key.  since the __repr__ from dataclass was overriding the custom one from UtilityClassConfig, the secret_key_params and api_key were not getting scrubbed before logging.

3) isna() doesn't always return a bool (e.g. if it's called on something arraylike, it returns a series or dataframe of bools, which causes a ValueError here).  the fix i've proposed will replace NaN things with self.value, but won't do anything with arraylike things for which some element is NaN (since in that case, it's unclear whether the user wants to replace the whole array with self.value or replace the offending elements with NaN, and I think in this case we should let it throw so that they can decide for themselves.  in any case i don't really expect eval datasets to contain arrays like [5, NaN, "hello"], so this is probably a non-issue).