### PR TITLE
add max_concurrent as a model parameter

### DIFF
--- a/eureka_ml_insights/core/inference.py
+++ b/eureka_ml_insights/core/inference.py
@@ -60,7 +60,12 @@ class Inference(Component):
         self.period = MINUTE
 
         # parallel inference parameters
-        self.max_concurrent = max_concurrent
+        if self.model.max_concurrent and hasattr(self.model, "handler"):
+            self.max_concurrent = self.model.max_concurrent * len(self.model.handler.clients)
+        elif self.model.max_concurrent:
+            self.max_concurrent = self.model.max_concurrent
+        else:
+            self.max_concurrent = max_concurrent
         self.chat_mode = chat_mode
         self.model.chat_mode = self.chat_mode
         self.output_dir = output_dir

--- a/eureka_ml_insights/models/models.py
+++ b/eureka_ml_insights/models/models.py
@@ -25,6 +25,7 @@ class Model(ABC):
     """
 
     chat_mode: bool = False
+    max_concurrent: int = None
 
     @abstractmethod
     def generate(self, text_prompt, *args, **kwargs):


### PR DESCRIPTION
This PR defines max_concurrent per-model, instead of per-eval (though the latter is still possible).

I've been facing an issue where, if I want to run an eval on 5 models, I need to manually change the max_concurrent parameter inside the eval between runs, which is not ideal for automating evals.  I've found it convenient to define max_concurrent on a per-model basis, since max_concurrent kind of just feels like a model parameter; mostly independent of which eval is being run, but variable based on model (or even based on ModelConfig --> some gateway 4o endpoints allow higher than trapi).

I also considered allowing it to be passed as a command line argument, but this isn't always sufficient, because some evals with llm-as-a-judge should be able to support different max_concurrent values for different parts of the eval.  