### PR TITLE
Added jinja-compatible positive-judgement example to math templates

### DIFF
--- a/eureka_ml_insights/prompt_templates/mathverse_templates/scoring_prompt.jinja
+++ b/eureka_ml_insights/prompt_templates/mathverse_templates/scoring_prompt.jinja
@@ -1,6 +1,6 @@
 Below are two answers to a math question. Question is [Question], [Standard Answer] is the standard answer to the question, and [Model_answer] is the answer extracted from a model's output to this question.  Determine whether these two answers are consistent.
-Please note that only when the [Model_answer] completely matches the [Standard Answer] means they are consistent. For non-multiple-choice questions, if the meaning is expressed in the same way, it is also considered consistent, for example, 0.5m and 50cm.
-If they are consistent, Judgment is 1; if they are different, Judgment is 0.
+Please note that only when the [Model_answer] completely matches the [Standard Answer] means they are consistent. For multiple choice questions, consider that the model answer may contain the letter representing the answer value. For non-multiple-choice questions, if the meaning is expressed in the same way, it is also considered consistent, for example, 0.5m and 50cm.
+If they are consistent, Judgement is 1; if they are different, Judgement is 0.  
 
 [Question]: Write the set of numbers represented on the number line in interval notation.
 [Standard Answer]: (-2,1]
@@ -22,7 +22,12 @@ Judgement: 0
 [Model_answer] : null
 Judgement: 0
 
-[Question]: {{question}}
+[Question]: Given the graph of the line that intersects with x-axis at -3 and with y-axis at 4, determine its equation. A. y = \\frac{{4}}{{3}}x + 4 B. Cannot determine.\n
+[Standard Answer]: A
+[Model_answer] : y = \\frac{{4}}{{3}}x + 4
+Judgement: 1
+
+[Question]: {{query}}
 [Standard Answer]: {{answer}}
 [Model_answer] : {{extraction}}
 Judgement: 

--- a/eureka_ml_insights/prompt_templates/mathvista_templates/scoring_prompt.jinja
+++ b/eureka_ml_insights/prompt_templates/mathvista_templates/scoring_prompt.jinja
@@ -1,6 +1,6 @@
 Below are two answers to a math question. Question is [Question], [Standard Answer] is the standard answer to the question, and [Model_answer] is the answer extracted from a model's output to this question.  Determine whether these two answers are consistent.
 Please note that only when the [Model_answer] completely matches the [Standard Answer] means they are consistent. For multiple choice questions, consider that the model answer may contain the letter representing the answer value. For non-multiple-choice questions, if the meaning is expressed in the same way, it is also considered consistent, for example, 0.5m and 50cm.
-If they are consistent, Judgment is 1; if they are different, Judgment is 0.  
+If they are consistent, Judgement is 1; if they are different, Judgement is 0.  
 
 [Question]: Write the set of numbers represented on the number line in interval notation.
 [Standard Answer]: (-2,1]
@@ -21,6 +21,11 @@ Judgement: 0
 [Standard Answer]: C
 [Model_answer] : null
 Judgement: 0
+
+[Question]: Given the graph of the line that intersects with x-axis at -3 and with y-axis at 4, determine its equation. A. y = \\frac{{4}}{{3}}x + 4 B. Cannot determine.\n
+[Standard Answer]: A
+[Model_answer] : y = \\frac{{4}}{{3}}x + 4
+Judgement: 1
 
 [Question]: {{query}}
 [Standard Answer]: {{answer}}


### PR DESCRIPTION
MathVerse and MathVista scoring templates had only contextual examples of Judgement 0 (where the model answer does not match the ground-truth). The [original MathVerse template](https://github.com/ZrrSkywalker/MathVerse/blob/937b090597aeafb8e82b35d310a4bc5b9e2ea29d/evaluation/prompts.py) included one example of Judgement 1, but it is incompatible with jinja due to the carat (^) character. This PR implements an example of Judgement 1 which is close to that of the original MathVerse template, but compatible with jinja. I also fixed a typo and standardized MathVerse/Vista instructions.